### PR TITLE
feat: timer_sleep busy waiting 제거

### DIFF
--- a/devices/timer.c
+++ b/devices/timer.c
@@ -20,6 +20,9 @@
 /* Number of timer ticks since OS booted. */
 static int64_t ticks;
 
+/* wake_tick 기준으로 정렬된 block상태의 스레드 리스트 */
+static struct list sleep_list;
+
 /* Number of loops per timer tick.
    Initialized by timer_calibrate(). */
 static unsigned loops_per_tick;
@@ -28,6 +31,7 @@ static intr_handler_func timer_interrupt;
 static bool too_many_loops(unsigned loops);
 static void busy_wait(int64_t loops);
 static void real_time_sleep(int64_t num, int32_t denom);
+static bool wakeup_tick_less(const struct list_elem* a, const struct list_elem* b, void* aux UNUSED);
 
 /* Sets up the 8254 Programmable Interval Timer (PIT) to
    interrupt PIT_FREQ times per second, and registers the
@@ -43,6 +47,7 @@ void timer_init(void)
     outb(0x40, count >> 8);
 
     intr_register_ext(0x20, timer_interrupt, "8254 Timer");
+    list_init(&sleep_list);
 }
 
 /* Calibrates loops_per_tick, used to implement brief delays. */
@@ -90,11 +95,17 @@ int64_t timer_elapsed(int64_t then)
 /* Suspends execution for approximately TICKS timer ticks. */
 void timer_sleep(int64_t ticks)
 {
-    int64_t start = timer_ticks();
+    struct thread* curr = thread_current();
+    int64_t wakeup_tick = timer_ticks() + ticks;
 
-    ASSERT(intr_get_level() == INTR_ON);
-    while (timer_elapsed(start) < ticks)
-        thread_yield();
+    enum intr_level old_level = intr_disable();
+    /* wake_tick 순서대로 정렬하여 sleep_list에 삽입 */
+    curr->wakeup_tick = wakeup_tick;
+    list_insert_ordered(&sleep_list, &curr->sleep_elem, wakeup_tick_less, NULL);
+
+    /* 스레드를 BLOCKED 상태로 전환 */
+    thread_block();
+    intr_set_level(old_level);
 }
 
 /* Suspends execution for approximately MS milliseconds. */
@@ -126,6 +137,19 @@ static void timer_interrupt(struct intr_frame* args UNUSED)
 {
     ticks++;
     thread_tick();
+
+    // sleep list 확인 및 깨우기
+    while (!list_empty(&sleep_list)) {
+        struct list_elem* e = list_begin(&sleep_list);
+        struct thread* t = list_entry(e, struct thread, sleep_elem);
+
+        if (t->wakeup_tick > ticks) {
+            break;
+        }
+
+        list_remove(e);
+        thread_unblock(t);
+    }
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer
@@ -183,4 +207,11 @@ static void real_time_sleep(int64_t num, int32_t denom)
         ASSERT(denom % 1000 == 0);
         busy_wait(loops_per_tick * num / 1000 * TIMER_FREQ / (denom / 1000));
     }
+}
+
+static bool wakeup_tick_less(const struct list_elem* a, const struct list_elem* b, void* aux UNUSED)
+{
+    struct thread* ta = list_entry(a, struct thread, sleep_elem);
+    struct thread* tb = list_entry(b, struct thread, sleep_elem);
+    return ta->wakeup_tick < tb->wakeup_tick;
 }

--- a/devices/timer.c
+++ b/devices/timer.c
@@ -25,125 +25,125 @@ static int64_t ticks;
 static unsigned loops_per_tick;
 
 static intr_handler_func timer_interrupt;
-static bool too_many_loops (unsigned loops);
-static void busy_wait (int64_t loops);
-static void real_time_sleep (int64_t num, int32_t denom);
+static bool too_many_loops(unsigned loops);
+static void busy_wait(int64_t loops);
+static void real_time_sleep(int64_t num, int32_t denom);
 
 /* Sets up the 8254 Programmable Interval Timer (PIT) to
    interrupt PIT_FREQ times per second, and registers the
    corresponding interrupt. */
-void
-timer_init (void) {
-	/* 8254 input frequency divided by TIMER_FREQ, rounded to
-	   nearest. */
-	uint16_t count = (1193180 + TIMER_FREQ / 2) / TIMER_FREQ;
+void timer_init(void)
+{
+    /* 8254 input frequency divided by TIMER_FREQ, rounded to
+       nearest. */
+    uint16_t count = (1193180 + TIMER_FREQ / 2) / TIMER_FREQ;
 
-	outb (0x43, 0x34);    /* CW: counter 0, LSB then MSB, mode 2, binary. */
-	outb (0x40, count & 0xff);
-	outb (0x40, count >> 8);
+    outb(0x43, 0x34); /* CW: counter 0, LSB then MSB, mode 2, binary. */
+    outb(0x40, count & 0xff);
+    outb(0x40, count >> 8);
 
-	intr_register_ext (0x20, timer_interrupt, "8254 Timer");
+    intr_register_ext(0x20, timer_interrupt, "8254 Timer");
 }
 
 /* Calibrates loops_per_tick, used to implement brief delays. */
-void
-timer_calibrate (void) {
-	unsigned high_bit, test_bit;
+void timer_calibrate(void)
+{
+    unsigned high_bit, test_bit;
 
-	ASSERT (intr_get_level () == INTR_ON);
-	printf ("Calibrating timer...  ");
+    ASSERT(intr_get_level() == INTR_ON);
+    printf("Calibrating timer...  ");
 
-	/* Approximate loops_per_tick as the largest power-of-two
-	   still less than one timer tick. */
-	loops_per_tick = 1u << 10;
-	while (!too_many_loops (loops_per_tick << 1)) {
-		loops_per_tick <<= 1;
-		ASSERT (loops_per_tick != 0);
-	}
+    /* Approximate loops_per_tick as the largest power-of-two
+       still less than one timer tick. */
+    loops_per_tick = 1u << 10;
+    while (!too_many_loops(loops_per_tick << 1)) {
+        loops_per_tick <<= 1;
+        ASSERT(loops_per_tick != 0);
+    }
 
-	/* Refine the next 8 bits of loops_per_tick. */
-	high_bit = loops_per_tick;
-	for (test_bit = high_bit >> 1; test_bit != high_bit >> 10; test_bit >>= 1)
-		if (!too_many_loops (high_bit | test_bit))
-			loops_per_tick |= test_bit;
+    /* Refine the next 8 bits of loops_per_tick. */
+    high_bit = loops_per_tick;
+    for (test_bit = high_bit >> 1; test_bit != high_bit >> 10; test_bit >>= 1)
+        if (!too_many_loops(high_bit | test_bit))
+            loops_per_tick |= test_bit;
 
-	printf ("%'"PRIu64" loops/s.\n", (uint64_t) loops_per_tick * TIMER_FREQ);
+    printf("%'" PRIu64 " loops/s.\n", (uint64_t)loops_per_tick * TIMER_FREQ);
 }
 
 /* Returns the number of timer ticks since the OS booted. */
-int64_t
-timer_ticks (void) {
-	enum intr_level old_level = intr_disable ();
-	int64_t t = ticks;
-	intr_set_level (old_level);
-	barrier ();
-	return t;
+int64_t timer_ticks(void)
+{
+    enum intr_level old_level = intr_disable();
+    int64_t t = ticks;
+    intr_set_level(old_level);
+    barrier();
+    return t;
 }
 
 /* Returns the number of timer ticks elapsed since THEN, which
    should be a value once returned by timer_ticks(). */
-int64_t
-timer_elapsed (int64_t then) {
-	return timer_ticks () - then;
+int64_t timer_elapsed(int64_t then)
+{
+    return timer_ticks() - then;
 }
 
 /* Suspends execution for approximately TICKS timer ticks. */
-void
-timer_sleep (int64_t ticks) {
-	int64_t start = timer_ticks ();
+void timer_sleep(int64_t ticks)
+{
+    int64_t start = timer_ticks();
 
-	ASSERT (intr_get_level () == INTR_ON);
-	while (timer_elapsed (start) < ticks)
-		thread_yield ();
+    ASSERT(intr_get_level() == INTR_ON);
+    while (timer_elapsed(start) < ticks)
+        thread_yield();
 }
 
 /* Suspends execution for approximately MS milliseconds. */
-void
-timer_msleep (int64_t ms) {
-	real_time_sleep (ms, 1000);
+void timer_msleep(int64_t ms)
+{
+    real_time_sleep(ms, 1000);
 }
 
 /* Suspends execution for approximately US microseconds. */
-void
-timer_usleep (int64_t us) {
-	real_time_sleep (us, 1000 * 1000);
+void timer_usleep(int64_t us)
+{
+    real_time_sleep(us, 1000 * 1000);
 }
 
 /* Suspends execution for approximately NS nanoseconds. */
-void
-timer_nsleep (int64_t ns) {
-	real_time_sleep (ns, 1000 * 1000 * 1000);
+void timer_nsleep(int64_t ns)
+{
+    real_time_sleep(ns, 1000 * 1000 * 1000);
 }
 
 /* Prints timer statistics. */
-void
-timer_print_stats (void) {
-	printf ("Timer: %"PRId64" ticks\n", timer_ticks ());
+void timer_print_stats(void)
+{
+    printf("Timer: %" PRId64 " ticks\n", timer_ticks());
 }
-
+
 /* Timer interrupt handler. */
-static void
-timer_interrupt (struct intr_frame *args UNUSED) {
-	ticks++;
-	thread_tick ();
+static void timer_interrupt(struct intr_frame* args UNUSED)
+{
+    ticks++;
+    thread_tick();
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer
    tick, otherwise false. */
-static bool
-too_many_loops (unsigned loops) {
-	/* Wait for a timer tick. */
-	int64_t start = ticks;
-	while (ticks == start)
-		barrier ();
+static bool too_many_loops(unsigned loops)
+{
+    /* Wait for a timer tick. */
+    int64_t start = ticks;
+    while (ticks == start)
+        barrier();
 
-	/* Run LOOPS loops. */
-	start = ticks;
-	busy_wait (loops);
+    /* Run LOOPS loops. */
+    start = ticks;
+    busy_wait(loops);
 
-	/* If the tick count changed, we iterated too long. */
-	barrier ();
-	return start != ticks;
+    /* If the tick count changed, we iterated too long. */
+    barrier();
+    return start != ticks;
 }
 
 /* Iterates through a simple loop LOOPS times, for implementing
@@ -153,34 +153,34 @@ too_many_loops (unsigned loops) {
    affect timings, so that if this function was inlined
    differently in different places the results would be difficult
    to predict. */
-static void NO_INLINE
-busy_wait (int64_t loops) {
-	while (loops-- > 0)
-		barrier ();
+static void NO_INLINE busy_wait(int64_t loops)
+{
+    while (loops-- > 0)
+        barrier();
 }
 
 /* Sleep for approximately NUM/DENOM seconds. */
-static void
-real_time_sleep (int64_t num, int32_t denom) {
-	/* Convert NUM/DENOM seconds into timer ticks, rounding down.
+static void real_time_sleep(int64_t num, int32_t denom)
+{
+    /* Convert NUM/DENOM seconds into timer ticks, rounding down.
 
-	   (NUM / DENOM) s
-	   ---------------------- = NUM * TIMER_FREQ / DENOM ticks.
-	   1 s / TIMER_FREQ ticks
-	   */
-	int64_t ticks = num * TIMER_FREQ / denom;
+       (NUM / DENOM) s
+       ---------------------- = NUM * TIMER_FREQ / DENOM ticks.
+       1 s / TIMER_FREQ ticks
+       */
+    int64_t ticks = num * TIMER_FREQ / denom;
 
-	ASSERT (intr_get_level () == INTR_ON);
-	if (ticks > 0) {
-		/* We're waiting for at least one full timer tick.  Use
-		   timer_sleep() because it will yield the CPU to other
-		   processes. */
-		timer_sleep (ticks);
-	} else {
-		/* Otherwise, use a busy-wait loop for more accurate
-		   sub-tick timing.  We scale the numerator and denominator
-		   down by 1000 to avoid the possibility of overflow. */
-		ASSERT (denom % 1000 == 0);
-		busy_wait (loops_per_tick * num / 1000 * TIMER_FREQ / (denom / 1000));
-	}
+    ASSERT(intr_get_level() == INTR_ON);
+    if (ticks > 0) {
+        /* We're waiting for at least one full timer tick.  Use
+           timer_sleep() because it will yield the CPU to other
+           processes. */
+        timer_sleep(ticks);
+    } else {
+        /* Otherwise, use a busy-wait loop for more accurate
+           sub-tick timing.  We scale the numerator and denominator
+           down by 1000 to avoid the possibility of overflow. */
+        ASSERT(denom % 1000 == 0);
+        busy_wait(loops_per_tick * num / 1000 * TIMER_FREQ / (denom / 1000));
+    }
 }

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -9,24 +9,23 @@
 #include "vm/vm.h"
 #endif
 
-
 /* States in a thread's life cycle. */
 enum thread_status {
-	THREAD_RUNNING,     /* Running thread. */
-	THREAD_READY,       /* Not running but ready to run. */
-	THREAD_BLOCKED,     /* Waiting for an event to trigger. */
-	THREAD_DYING        /* About to be destroyed. */
+    THREAD_RUNNING, /* Running thread. */
+    THREAD_READY,   /* Not running but ready to run. */
+    THREAD_BLOCKED, /* Waiting for an event to trigger. */
+    THREAD_DYING    /* About to be destroyed. */
 };
 
 /* Thread identifier type.
    You can redefine this to whatever type you like. */
 typedef int tid_t;
-#define TID_ERROR ((tid_t) -1)          /* Error value for tid_t. */
+#define TID_ERROR ((tid_t) - 1) /* Error value for tid_t. */
 
 /* Thread priorities. */
-#define PRI_MIN 0                       /* Lowest priority. */
-#define PRI_DEFAULT 31                  /* Default priority. */
-#define PRI_MAX 63                      /* Highest priority. */
+#define PRI_MIN 0      /* Lowest priority. */
+#define PRI_DEFAULT 31 /* Default priority. */
+#define PRI_MAX 63     /* Highest priority. */
 
 /* A kernel thread or user process.
  *
@@ -86,27 +85,27 @@ typedef int tid_t;
  * ready state is on the run queue, whereas only a thread in the
  * blocked state is on a semaphore wait list. */
 struct thread {
-	/* Owned by thread.c. */
-	tid_t tid;                          /* Thread identifier. */
-	enum thread_status status;          /* Thread state. */
-	char name[16];                      /* Name (for debugging purposes). */
-	int priority;                       /* Priority. */
+    /* Owned by thread.c. */
+    tid_t tid;                 /* Thread identifier. */
+    enum thread_status status; /* Thread state. */
+    char name[16];             /* Name (for debugging purposes). */
+    int priority;              /* Priority. */
 
-	/* Shared between thread.c and synch.c. */
-	struct list_elem elem;              /* List element. */
+    /* Shared between thread.c and synch.c. */
+    struct list_elem elem; /* List element. */
 
 #ifdef USERPROG
-	/* Owned by userprog/process.c. */
-	uint64_t *pml4;                     /* Page map level 4 */
+    /* Owned by userprog/process.c. */
+    uint64_t* pml4; /* Page map level 4 */
 #endif
 #ifdef VM
-	/* Table for whole virtual memory owned by thread. */
-	struct supplemental_page_table spt;
+    /* Table for whole virtual memory owned by thread. */
+    struct supplemental_page_table spt;
 #endif
 
-	/* Owned by thread.c. */
-	struct intr_frame tf;               /* Information for switching */
-	unsigned magic;                     /* Detects stack overflow. */
+    /* Owned by thread.c. */
+    struct intr_frame tf; /* Information for switching */
+    unsigned magic;       /* Detects stack overflow. */
 };
 
 /* If false (default), use round-robin scheduler.
@@ -114,33 +113,33 @@ struct thread {
    Controlled by kernel command-line option "-o mlfqs". */
 extern bool thread_mlfqs;
 
-void thread_init (void);
-void thread_start (void);
+void thread_init(void);
+void thread_start(void);
 
-void thread_tick (void);
-void thread_print_stats (void);
+void thread_tick(void);
+void thread_print_stats(void);
 
-typedef void thread_func (void *aux);
-tid_t thread_create (const char *name, int priority, thread_func *, void *);
+typedef void thread_func(void* aux);
+tid_t thread_create(const char* name, int priority, thread_func*, void*);
 
-void thread_block (void);
-void thread_unblock (struct thread *);
+void thread_block(void);
+void thread_unblock(struct thread*);
 
-struct thread *thread_current (void);
-tid_t thread_tid (void);
-const char *thread_name (void);
+struct thread* thread_current(void);
+tid_t thread_tid(void);
+const char* thread_name(void);
 
-void thread_exit (void) NO_RETURN;
-void thread_yield (void);
+void thread_exit(void) NO_RETURN;
+void thread_yield(void);
 
-int thread_get_priority (void);
-void thread_set_priority (int);
+int thread_get_priority(void);
+void thread_set_priority(int);
 
-int thread_get_nice (void);
-void thread_set_nice (int);
-int thread_get_recent_cpu (void);
-int thread_get_load_avg (void);
+int thread_get_nice(void);
+void thread_set_nice(int);
+int thread_get_recent_cpu(void);
+int thread_get_load_avg(void);
 
-void do_iret (struct intr_frame *tf);
+void do_iret(struct intr_frame* tf);
 
 #endif /* threads/thread.h */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -94,6 +94,9 @@ struct thread {
     /* Shared between thread.c and synch.c. */
     struct list_elem elem; /* List element. */
 
+    int64_t wakeup_tick;         /* Thread가 일어나야 할 tick */
+    struct list_elem sleep_elem; /* block상태의 Thread 리스트 요소 */
+
 #ifdef USERPROG
     /* Owned by userprog/process.c. */
     uint64_t* pml4; /* Page map level 4 */

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -29,10 +29,10 @@
 static struct list ready_list;
 
 /* Idle thread. */
-static struct thread *idle_thread;
+static struct thread* idle_thread;
 
 /* Initial thread, the thread running init.c:main(). */
-static struct thread *initial_thread;
+static struct thread* initial_thread;
 
 /* Lock used by allocate_tid(). */
 static struct lock tid_lock;
@@ -41,27 +41,27 @@ static struct lock tid_lock;
 static struct list destruction_req;
 
 /* Statistics. */
-static long long idle_ticks;    /* # of timer ticks spent idle. */
-static long long kernel_ticks;  /* # of timer ticks in kernel threads. */
-static long long user_ticks;    /* # of timer ticks in user programs. */
+static long long idle_ticks;   /* # of timer ticks spent idle. */
+static long long kernel_ticks; /* # of timer ticks in kernel threads. */
+static long long user_ticks;   /* # of timer ticks in user programs. */
 
 /* Scheduling. */
-#define TIME_SLICE 4            /* # of timer ticks to give each thread. */
-static unsigned thread_ticks;   /* # of timer ticks since last yield. */
+#define TIME_SLICE 4          /* # of timer ticks to give each thread. */
+static unsigned thread_ticks; /* # of timer ticks since last yield. */
 
 /* If false (default), use round-robin scheduler.
    If true, use multi-level feedback queue scheduler.
    Controlled by kernel command-line option "-o mlfqs". */
 bool thread_mlfqs;
 
-static void kernel_thread (thread_func *, void *aux);
+static void kernel_thread(thread_func*, void* aux);
 
-static void idle (void *aux UNUSED);
-static struct thread *next_thread_to_run (void);
-static void init_thread (struct thread *, const char *name, int priority);
+static void idle(void* aux UNUSED);
+static struct thread* next_thread_to_run(void);
+static void init_thread(struct thread*, const char* name, int priority);
 static void do_schedule(int status);
-static void schedule (void);
-static tid_t allocate_tid (void);
+static void schedule(void);
+static tid_t allocate_tid(void);
 
 /* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
@@ -71,13 +71,12 @@ static tid_t allocate_tid (void);
  * down to the start of a page.  Since `struct thread' is
  * always at the beginning of a page and the stack pointer is
  * somewhere in the middle, this locates the curent thread. */
-#define running_thread() ((struct thread *) (pg_round_down (rrsp ())))
-
+#define running_thread() ((struct thread*)(pg_round_down(rrsp())))
 
 // Global descriptor table for the thread_start.
 // Because the gdt will be setup after the thread_init, we should
 // setup temporal gdt first.
-static uint64_t gdt[3] = { 0, 0x00af9a000000ffff, 0x00cf92000000ffff };
+static uint64_t gdt[3] = {0, 0x00af9a000000ffff, 0x00cf92000000ffff};
 
 /* Initializes the threading system by transforming the code
    that's currently running into a thread.  This can't work in
@@ -92,73 +91,69 @@ static uint64_t gdt[3] = { 0, 0x00af9a000000ffff, 0x00cf92000000ffff };
 
    It is not safe to call thread_current() until this function
    finishes. */
-void
-thread_init (void) {
-	ASSERT (intr_get_level () == INTR_OFF);
+void thread_init(void)
+{
+    ASSERT(intr_get_level() == INTR_OFF);
 
-	/* Reload the temporal gdt for the kernel
-	 * This gdt does not include the user context.
-	 * The kernel will rebuild the gdt with user context, in gdt_init (). */
-	struct desc_ptr gdt_ds = {
-		.size = sizeof (gdt) - 1,
-		.address = (uint64_t) gdt
-	};
-	lgdt (&gdt_ds);
+    /* Reload the temporal gdt for the kernel
+     * This gdt does not include the user context.
+     * The kernel will rebuild the gdt with user context, in gdt_init (). */
+    struct desc_ptr gdt_ds = {.size = sizeof(gdt) - 1, .address = (uint64_t)gdt};
+    lgdt(&gdt_ds);
 
-	/* Init the globla thread context */
-	lock_init (&tid_lock);
-	list_init (&ready_list);
-	list_init (&destruction_req);
+    /* Init the globla thread context */
+    lock_init(&tid_lock);
+    list_init(&ready_list);
+    list_init(&destruction_req);
 
-	/* Set up a thread structure for the running thread. */
-	initial_thread = running_thread ();
-	init_thread (initial_thread, "main", PRI_DEFAULT);
-	initial_thread->status = THREAD_RUNNING;
-	initial_thread->tid = allocate_tid ();
+    /* Set up a thread structure for the running thread. */
+    initial_thread = running_thread();
+    init_thread(initial_thread, "main", PRI_DEFAULT);
+    initial_thread->status = THREAD_RUNNING;
+    initial_thread->tid = allocate_tid();
 }
 
 /* Starts preemptive thread scheduling by enabling interrupts.
    Also creates the idle thread. */
-void
-thread_start (void) {
-	/* Create the idle thread. */
-	struct semaphore idle_started;
-	sema_init (&idle_started, 0);
-	thread_create ("idle", PRI_MIN, idle, &idle_started);
+void thread_start(void)
+{
+    /* Create the idle thread. */
+    struct semaphore idle_started;
+    sema_init(&idle_started, 0);
+    thread_create("idle", PRI_MIN, idle, &idle_started);
 
-	/* Start preemptive thread scheduling. */
-	intr_enable ();
+    /* Start preemptive thread scheduling. */
+    intr_enable();
 
-	/* Wait for the idle thread to initialize idle_thread. */
-	sema_down (&idle_started);
+    /* Wait for the idle thread to initialize idle_thread. */
+    sema_down(&idle_started);
 }
 
 /* Called by the timer interrupt handler at each timer tick.
    Thus, this function runs in an external interrupt context. */
-void
-thread_tick (void) {
-	struct thread *t = thread_current ();
+void thread_tick(void)
+{
+    struct thread* t = thread_current();
 
-	/* Update statistics. */
-	if (t == idle_thread)
-		idle_ticks++;
+    /* Update statistics. */
+    if (t == idle_thread)
+        idle_ticks++;
 #ifdef USERPROG
-	else if (t->pml4 != NULL)
-		user_ticks++;
+    else if (t->pml4 != NULL)
+        user_ticks++;
 #endif
-	else
-		kernel_ticks++;
+    else
+        kernel_ticks++;
 
-	/* Enforce preemption. */
-	if (++thread_ticks >= TIME_SLICE)
-		intr_yield_on_return ();
+    /* Enforce preemption. */
+    if (++thread_ticks >= TIME_SLICE)
+        intr_yield_on_return();
 }
 
 /* Prints thread statistics. */
-void
-thread_print_stats (void) {
-	printf ("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n",
-			idle_ticks, kernel_ticks, user_ticks);
+void thread_print_stats(void)
+{
+    printf("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n", idle_ticks, kernel_ticks, user_ticks);
 }
 
 /* Creates a new kernel thread named NAME with the given initial
@@ -176,38 +171,37 @@ thread_print_stats (void) {
    The code provided sets the new thread's `priority' member to
    PRIORITY, but no actual priority scheduling is implemented.
    Priority scheduling is the goal of Problem 1-3. */
-tid_t
-thread_create (const char *name, int priority,
-		thread_func *function, void *aux) {
-	struct thread *t;
-	tid_t tid;
+tid_t thread_create(const char* name, int priority, thread_func* function, void* aux)
+{
+    struct thread* t;
+    tid_t tid;
 
-	ASSERT (function != NULL);
+    ASSERT(function != NULL);
 
-	/* Allocate thread. */
-	t = palloc_get_page (PAL_ZERO);
-	if (t == NULL)
-		return TID_ERROR;
+    /* Allocate thread. */
+    t = palloc_get_page(PAL_ZERO);
+    if (t == NULL)
+        return TID_ERROR;
 
-	/* Initialize thread. */
-	init_thread (t, name, priority);
-	tid = t->tid = allocate_tid ();
+    /* Initialize thread. */
+    init_thread(t, name, priority);
+    tid = t->tid = allocate_tid();
 
-	/* Call the kernel_thread if it scheduled.
-	 * Note) rdi is 1st argument, and rsi is 2nd argument. */
-	t->tf.rip = (uintptr_t) kernel_thread;
-	t->tf.R.rdi = (uint64_t) function;
-	t->tf.R.rsi = (uint64_t) aux;
-	t->tf.ds = SEL_KDSEG;
-	t->tf.es = SEL_KDSEG;
-	t->tf.ss = SEL_KDSEG;
-	t->tf.cs = SEL_KCSEG;
-	t->tf.eflags = FLAG_IF;
+    /* Call the kernel_thread if it scheduled.
+     * Note) rdi is 1st argument, and rsi is 2nd argument. */
+    t->tf.rip = (uintptr_t)kernel_thread;
+    t->tf.R.rdi = (uint64_t)function;
+    t->tf.R.rsi = (uint64_t)aux;
+    t->tf.ds = SEL_KDSEG;
+    t->tf.es = SEL_KDSEG;
+    t->tf.ss = SEL_KDSEG;
+    t->tf.cs = SEL_KCSEG;
+    t->tf.eflags = FLAG_IF;
 
-	/* Add to run queue. */
-	thread_unblock (t);
+    /* Add to run queue. */
+    thread_unblock(t);
 
-	return tid;
+    return tid;
 }
 
 /* Puts the current thread to sleep.  It will not be scheduled
@@ -216,12 +210,12 @@ thread_create (const char *name, int priority,
    This function must be called with interrupts turned off.  It
    is usually a better idea to use one of the synchronization
    primitives in synch.h. */
-void
-thread_block (void) {
-	ASSERT (!intr_context ());
-	ASSERT (intr_get_level () == INTR_OFF);
-	thread_current ()->status = THREAD_BLOCKED;
-	schedule ();
+void thread_block(void)
+{
+    ASSERT(!intr_context());
+    ASSERT(intr_get_level() == INTR_OFF);
+    thread_current()->status = THREAD_BLOCKED;
+    schedule();
 }
 
 /* Transitions a blocked thread T to the ready-to-run state.
@@ -232,119 +226,119 @@ thread_block (void) {
    be important: if the caller had disabled interrupts itself,
    it may expect that it can atomically unblock a thread and
    update other data. */
-void
-thread_unblock (struct thread *t) {
-	enum intr_level old_level;
+void thread_unblock(struct thread* t)
+{
+    enum intr_level old_level;
 
-	ASSERT (is_thread (t));
+    ASSERT(is_thread(t));
 
-	old_level = intr_disable ();
-	ASSERT (t->status == THREAD_BLOCKED);
-	list_push_back (&ready_list, &t->elem);
-	t->status = THREAD_READY;
-	intr_set_level (old_level);
+    old_level = intr_disable();
+    ASSERT(t->status == THREAD_BLOCKED);
+    list_push_back(&ready_list, &t->elem);
+    t->status = THREAD_READY;
+    intr_set_level(old_level);
 }
 
 /* Returns the name of the running thread. */
-const char *
-thread_name (void) {
-	return thread_current ()->name;
+const char* thread_name(void)
+{
+    return thread_current()->name;
 }
 
 /* Returns the running thread.
    This is running_thread() plus a couple of sanity checks.
    See the big comment at the top of thread.h for details. */
-struct thread *
-thread_current (void) {
-	struct thread *t = running_thread ();
+struct thread* thread_current(void)
+{
+    struct thread* t = running_thread();
 
-	/* Make sure T is really a thread.
-	   If either of these assertions fire, then your thread may
-	   have overflowed its stack.  Each thread has less than 4 kB
-	   of stack, so a few big automatic arrays or moderate
-	   recursion can cause stack overflow. */
-	ASSERT (is_thread (t));
-	ASSERT (t->status == THREAD_RUNNING);
+    /* Make sure T is really a thread.
+       If either of these assertions fire, then your thread may
+       have overflowed its stack.  Each thread has less than 4 kB
+       of stack, so a few big automatic arrays or moderate
+       recursion can cause stack overflow. */
+    ASSERT(is_thread(t));
+    ASSERT(t->status == THREAD_RUNNING);
 
-	return t;
+    return t;
 }
 
 /* Returns the running thread's tid. */
-tid_t
-thread_tid (void) {
-	return thread_current ()->tid;
+tid_t thread_tid(void)
+{
+    return thread_current()->tid;
 }
 
 /* Deschedules the current thread and destroys it.  Never
    returns to the caller. */
-void
-thread_exit (void) {
-	ASSERT (!intr_context ());
+void thread_exit(void)
+{
+    ASSERT(!intr_context());
 
 #ifdef USERPROG
-	process_exit ();
+    process_exit();
 #endif
 
-	/* Just set our status to dying and schedule another process.
-	   We will be destroyed during the call to schedule_tail(). */
-	intr_disable ();
-	do_schedule (THREAD_DYING);
-	NOT_REACHED ();
+    /* Just set our status to dying and schedule another process.
+       We will be destroyed during the call to schedule_tail(). */
+    intr_disable();
+    do_schedule(THREAD_DYING);
+    NOT_REACHED();
 }
 
 /* Yields the CPU.  The current thread is not put to sleep and
    may be scheduled again immediately at the scheduler's whim. */
-void
-thread_yield (void) {
-	struct thread *curr = thread_current ();
-	enum intr_level old_level;
+void thread_yield(void)
+{
+    struct thread* curr = thread_current();
+    enum intr_level old_level;
 
-	ASSERT (!intr_context ());
+    ASSERT(!intr_context());
 
-	old_level = intr_disable ();
-	if (curr != idle_thread)
-		list_push_back (&ready_list, &curr->elem);
-	do_schedule (THREAD_READY);
-	intr_set_level (old_level);
+    old_level = intr_disable();
+    if (curr != idle_thread)
+        list_push_back(&ready_list, &curr->elem);
+    do_schedule(THREAD_READY);
+    intr_set_level(old_level);
 }
 
 /* Sets the current thread's priority to NEW_PRIORITY. */
-void
-thread_set_priority (int new_priority) {
-	thread_current ()->priority = new_priority;
+void thread_set_priority(int new_priority)
+{
+    thread_current()->priority = new_priority;
 }
 
 /* Returns the current thread's priority. */
-int
-thread_get_priority (void) {
-	return thread_current ()->priority;
+int thread_get_priority(void)
+{
+    return thread_current()->priority;
 }
 
 /* Sets the current thread's nice value to NICE. */
-void
-thread_set_nice (int nice UNUSED) {
-	/* TODO: Your implementation goes here */
+void thread_set_nice(int nice UNUSED)
+{
+    /* TODO: Your implementation goes here */
 }
 
 /* Returns the current thread's nice value. */
-int
-thread_get_nice (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+int thread_get_nice(void)
+{
+    /* TODO: Your implementation goes here */
+    return 0;
 }
 
 /* Returns 100 times the system load average. */
-int
-thread_get_load_avg (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+int thread_get_load_avg(void)
+{
+    /* TODO: Your implementation goes here */
+    return 0;
 }
 
 /* Returns 100 times the current thread's recent_cpu value. */
-int
-thread_get_recent_cpu (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+int thread_get_recent_cpu(void)
+{
+    /* TODO: Your implementation goes here */
+    return 0;
 }
 
 /* Idle thread.  Executes when no other thread is ready to run.
@@ -356,59 +350,58 @@ thread_get_recent_cpu (void) {
    blocks.  After that, the idle thread never appears in the
    ready list.  It is returned by next_thread_to_run() as a
    special case when the ready list is empty. */
-static void
-idle (void *idle_started_ UNUSED) {
-	struct semaphore *idle_started = idle_started_;
+static void idle(void* idle_started_ UNUSED)
+{
+    struct semaphore* idle_started = idle_started_;
 
-	idle_thread = thread_current ();
-	sema_up (idle_started);
+    idle_thread = thread_current();
+    sema_up(idle_started);
 
-	for (;;) {
-		/* Let someone else run. */
-		intr_disable ();
-		thread_block ();
+    for (;;) {
+        /* Let someone else run. */
+        intr_disable();
+        thread_block();
 
-		/* Re-enable interrupts and wait for the next one.
+        /* Re-enable interrupts and wait for the next one.
 
-		   The `sti' instruction disables interrupts until the
-		   completion of the next instruction, so these two
-		   instructions are executed atomically.  This atomicity is
-		   important; otherwise, an interrupt could be handled
-		   between re-enabling interrupts and waiting for the next
-		   one to occur, wasting as much as one clock tick worth of
-		   time.
+           The `sti' instruction disables interrupts until the
+           completion of the next instruction, so these two
+           instructions are executed atomically.  This atomicity is
+           important; otherwise, an interrupt could be handled
+           between re-enabling interrupts and waiting for the next
+           one to occur, wasting as much as one clock tick worth of
+           time.
 
-		   See [IA32-v2a] "HLT", [IA32-v2b] "STI", and [IA32-v3a]
-		   7.11.1 "HLT Instruction". */
-		asm volatile ("sti; hlt" : : : "memory");
-	}
+           See [IA32-v2a] "HLT", [IA32-v2b] "STI", and [IA32-v3a]
+           7.11.1 "HLT Instruction". */
+        asm volatile("sti; hlt" : : : "memory");
+    }
 }
 
 /* Function used as the basis for a kernel thread. */
-static void
-kernel_thread (thread_func *function, void *aux) {
-	ASSERT (function != NULL);
+static void kernel_thread(thread_func* function, void* aux)
+{
+    ASSERT(function != NULL);
 
-	intr_enable ();       /* The scheduler runs with interrupts off. */
-	function (aux);       /* Execute the thread function. */
-	thread_exit ();       /* If function() returns, kill the thread. */
+    intr_enable(); /* The scheduler runs with interrupts off. */
+    function(aux); /* Execute the thread function. */
+    thread_exit(); /* If function() returns, kill the thread. */
 }
-
 
 /* Does basic initialization of T as a blocked thread named
    NAME. */
-static void
-init_thread (struct thread *t, const char *name, int priority) {
-	ASSERT (t != NULL);
-	ASSERT (PRI_MIN <= priority && priority <= PRI_MAX);
-	ASSERT (name != NULL);
+static void init_thread(struct thread* t, const char* name, int priority)
+{
+    ASSERT(t != NULL);
+    ASSERT(PRI_MIN <= priority && priority <= PRI_MAX);
+    ASSERT(name != NULL);
 
-	memset (t, 0, sizeof *t);
-	t->status = THREAD_BLOCKED;
-	strlcpy (t->name, name, sizeof t->name);
-	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
-	t->priority = priority;
-	t->magic = THREAD_MAGIC;
+    memset(t, 0, sizeof *t);
+    t->status = THREAD_BLOCKED;
+    strlcpy(t->name, name, sizeof t->name);
+    t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void*);
+    t->priority = priority;
+    t->magic = THREAD_MAGIC;
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should
@@ -416,40 +409,41 @@ init_thread (struct thread *t, const char *name, int priority) {
    empty.  (If the running thread can continue running, then it
    will be in the run queue.)  If the run queue is empty, return
    idle_thread. */
-static struct thread *
-next_thread_to_run (void) {
-	if (list_empty (&ready_list))
-		return idle_thread;
-	else
-		return list_entry (list_pop_front (&ready_list), struct thread, elem);
+static struct thread* next_thread_to_run(void)
+{
+    if (list_empty(&ready_list))
+        return idle_thread;
+    else
+        return list_entry(list_pop_front(&ready_list), struct thread, elem);
 }
 
 /* Use iretq to launch the thread */
-void
-do_iret (struct intr_frame *tf) {
-	__asm __volatile(
-			"movq %0, %%rsp\n"
-			"movq 0(%%rsp),%%r15\n"
-			"movq 8(%%rsp),%%r14\n"
-			"movq 16(%%rsp),%%r13\n"
-			"movq 24(%%rsp),%%r12\n"
-			"movq 32(%%rsp),%%r11\n"
-			"movq 40(%%rsp),%%r10\n"
-			"movq 48(%%rsp),%%r9\n"
-			"movq 56(%%rsp),%%r8\n"
-			"movq 64(%%rsp),%%rsi\n"
-			"movq 72(%%rsp),%%rdi\n"
-			"movq 80(%%rsp),%%rbp\n"
-			"movq 88(%%rsp),%%rdx\n"
-			"movq 96(%%rsp),%%rcx\n"
-			"movq 104(%%rsp),%%rbx\n"
-			"movq 112(%%rsp),%%rax\n"
-			"addq $120,%%rsp\n"
-			"movw 8(%%rsp),%%ds\n"
-			"movw (%%rsp),%%es\n"
-			"addq $32, %%rsp\n"
-			"iretq"
-			: : "g" ((uint64_t) tf) : "memory");
+void do_iret(struct intr_frame* tf)
+{
+    __asm __volatile("movq %0, %%rsp\n"
+                     "movq 0(%%rsp),%%r15\n"
+                     "movq 8(%%rsp),%%r14\n"
+                     "movq 16(%%rsp),%%r13\n"
+                     "movq 24(%%rsp),%%r12\n"
+                     "movq 32(%%rsp),%%r11\n"
+                     "movq 40(%%rsp),%%r10\n"
+                     "movq 48(%%rsp),%%r9\n"
+                     "movq 56(%%rsp),%%r8\n"
+                     "movq 64(%%rsp),%%rsi\n"
+                     "movq 72(%%rsp),%%rdi\n"
+                     "movq 80(%%rsp),%%rbp\n"
+                     "movq 88(%%rsp),%%rdx\n"
+                     "movq 96(%%rsp),%%rcx\n"
+                     "movq 104(%%rsp),%%rbx\n"
+                     "movq 112(%%rsp),%%rax\n"
+                     "addq $120,%%rsp\n"
+                     "movw 8(%%rsp),%%ds\n"
+                     "movw (%%rsp),%%es\n"
+                     "addq $32, %%rsp\n"
+                     "iretq"
+                     :
+                     : "g"((uint64_t)tf)
+                     : "memory");
 }
 
 /* Switching the thread by activating the new thread's page
@@ -462,129 +456,129 @@ do_iret (struct intr_frame *tf) {
    It's not safe to call printf() until the thread switch is
    complete.  In practice that means that printf()s should be
    added at the end of the function. */
-static void
-thread_launch (struct thread *th) {
-	uint64_t tf_cur = (uint64_t) &running_thread ()->tf;
-	uint64_t tf = (uint64_t) &th->tf;
-	ASSERT (intr_get_level () == INTR_OFF);
+static void thread_launch(struct thread* th)
+{
+    uint64_t tf_cur = (uint64_t)&running_thread()->tf;
+    uint64_t tf = (uint64_t)&th->tf;
+    ASSERT(intr_get_level() == INTR_OFF);
 
-	/* The main switching logic.
-	 * We first restore the whole execution context into the intr_frame
-	 * and then switching to the next thread by calling do_iret.
-	 * Note that, we SHOULD NOT use any stack from here
-	 * until switching is done. */
-	__asm __volatile (
-			/* Store registers that will be used. */
-			"push %%rax\n"
-			"push %%rbx\n"
-			"push %%rcx\n"
-			/* Fetch input once */
-			"movq %0, %%rax\n"
-			"movq %1, %%rcx\n"
-			"movq %%r15, 0(%%rax)\n"
-			"movq %%r14, 8(%%rax)\n"
-			"movq %%r13, 16(%%rax)\n"
-			"movq %%r12, 24(%%rax)\n"
-			"movq %%r11, 32(%%rax)\n"
-			"movq %%r10, 40(%%rax)\n"
-			"movq %%r9, 48(%%rax)\n"
-			"movq %%r8, 56(%%rax)\n"
-			"movq %%rsi, 64(%%rax)\n"
-			"movq %%rdi, 72(%%rax)\n"
-			"movq %%rbp, 80(%%rax)\n"
-			"movq %%rdx, 88(%%rax)\n"
-			"pop %%rbx\n"              // Saved rcx
-			"movq %%rbx, 96(%%rax)\n"
-			"pop %%rbx\n"              // Saved rbx
-			"movq %%rbx, 104(%%rax)\n"
-			"pop %%rbx\n"              // Saved rax
-			"movq %%rbx, 112(%%rax)\n"
-			"addq $120, %%rax\n"
-			"movw %%es, (%%rax)\n"
-			"movw %%ds, 8(%%rax)\n"
-			"addq $32, %%rax\n"
-			"call __next\n"         // read the current rip.
-			"__next:\n"
-			"pop %%rbx\n"
-			"addq $(out_iret -  __next), %%rbx\n"
-			"movq %%rbx, 0(%%rax)\n" // rip
-			"movw %%cs, 8(%%rax)\n"  // cs
-			"pushfq\n"
-			"popq %%rbx\n"
-			"mov %%rbx, 16(%%rax)\n" // eflags
-			"mov %%rsp, 24(%%rax)\n" // rsp
-			"movw %%ss, 32(%%rax)\n"
-			"mov %%rcx, %%rdi\n"
-			"call do_iret\n"
-			"out_iret:\n"
-			: : "g"(tf_cur), "g" (tf) : "memory"
-			);
+    /* The main switching logic.
+     * We first restore the whole execution context into the intr_frame
+     * and then switching to the next thread by calling do_iret.
+     * Note that, we SHOULD NOT use any stack from here
+     * until switching is done. */
+    __asm __volatile(
+        /* Store registers that will be used. */
+        "push %%rax\n"
+        "push %%rbx\n"
+        "push %%rcx\n"
+        /* Fetch input once */
+        "movq %0, %%rax\n"
+        "movq %1, %%rcx\n"
+        "movq %%r15, 0(%%rax)\n"
+        "movq %%r14, 8(%%rax)\n"
+        "movq %%r13, 16(%%rax)\n"
+        "movq %%r12, 24(%%rax)\n"
+        "movq %%r11, 32(%%rax)\n"
+        "movq %%r10, 40(%%rax)\n"
+        "movq %%r9, 48(%%rax)\n"
+        "movq %%r8, 56(%%rax)\n"
+        "movq %%rsi, 64(%%rax)\n"
+        "movq %%rdi, 72(%%rax)\n"
+        "movq %%rbp, 80(%%rax)\n"
+        "movq %%rdx, 88(%%rax)\n"
+        "pop %%rbx\n" // Saved rcx
+        "movq %%rbx, 96(%%rax)\n"
+        "pop %%rbx\n" // Saved rbx
+        "movq %%rbx, 104(%%rax)\n"
+        "pop %%rbx\n" // Saved rax
+        "movq %%rbx, 112(%%rax)\n"
+        "addq $120, %%rax\n"
+        "movw %%es, (%%rax)\n"
+        "movw %%ds, 8(%%rax)\n"
+        "addq $32, %%rax\n"
+        "call __next\n" // read the current rip.
+        "__next:\n"
+        "pop %%rbx\n"
+        "addq $(out_iret -  __next), %%rbx\n"
+        "movq %%rbx, 0(%%rax)\n" // rip
+        "movw %%cs, 8(%%rax)\n"  // cs
+        "pushfq\n"
+        "popq %%rbx\n"
+        "mov %%rbx, 16(%%rax)\n" // eflags
+        "mov %%rsp, 24(%%rax)\n" // rsp
+        "movw %%ss, 32(%%rax)\n"
+        "mov %%rcx, %%rdi\n"
+        "call do_iret\n"
+        "out_iret:\n"
+        :
+        : "g"(tf_cur), "g"(tf)
+        : "memory");
 }
 
 /* Schedules a new process. At entry, interrupts must be off.
  * This function modify current thread's status to status and then
  * finds another thread to run and switches to it.
  * It's not safe to call printf() in the schedule(). */
-static void
-do_schedule(int status) {
-	ASSERT (intr_get_level () == INTR_OFF);
-	ASSERT (thread_current()->status == THREAD_RUNNING);
-	while (!list_empty (&destruction_req)) {
-		struct thread *victim =
-			list_entry (list_pop_front (&destruction_req), struct thread, elem);
-		palloc_free_page(victim);
-	}
-	thread_current ()->status = status;
-	schedule ();
+static void do_schedule(int status)
+{
+    ASSERT(intr_get_level() == INTR_OFF);
+    ASSERT(thread_current()->status == THREAD_RUNNING);
+    while (!list_empty(&destruction_req)) {
+        struct thread* victim = list_entry(list_pop_front(&destruction_req), struct thread, elem);
+        palloc_free_page(victim);
+    }
+    thread_current()->status = status;
+    schedule();
 }
 
-static void
-schedule (void) {
-	struct thread *curr = running_thread ();
-	struct thread *next = next_thread_to_run ();
+static void schedule(void)
+{
+    struct thread* curr = running_thread();
+    struct thread* next = next_thread_to_run();
 
-	ASSERT (intr_get_level () == INTR_OFF);
-	ASSERT (curr->status != THREAD_RUNNING);
-	ASSERT (is_thread (next));
-	/* Mark us as running. */
-	next->status = THREAD_RUNNING;
+    ASSERT(intr_get_level() == INTR_OFF);
+    ASSERT(curr->status != THREAD_RUNNING);
+    ASSERT(is_thread(next));
+    /* Mark us as running. */
+    next->status = THREAD_RUNNING;
 
-	/* Start new time slice. */
-	thread_ticks = 0;
+    /* Start new time slice. */
+    thread_ticks = 0;
 
 #ifdef USERPROG
-	/* Activate the new address space. */
-	process_activate (next);
+    /* Activate the new address space. */
+    process_activate(next);
 #endif
 
-	if (curr != next) {
-		/* If the thread we switched from is dying, destroy its struct
-		   thread. This must happen late so that thread_exit() doesn't
-		   pull out the rug under itself.
-		   We just queuing the page free reqeust here because the page is
-		   currently used by the stack.
-		   The real destruction logic will be called at the beginning of the
-		   schedule(). */
-		if (curr && curr->status == THREAD_DYING && curr != initial_thread) {
-			ASSERT (curr != next);
-			list_push_back (&destruction_req, &curr->elem);
-		}
+    if (curr != next) {
+        /* If the thread we switched from is dying, destroy its struct
+           thread. This must happen late so that thread_exit() doesn't
+           pull out the rug under itself.
+           We just queuing the page free reqeust here because the page is
+           currently used by the stack.
+           The real destruction logic will be called at the beginning of the
+           schedule(). */
+        if (curr && curr->status == THREAD_DYING && curr != initial_thread) {
+            ASSERT(curr != next);
+            list_push_back(&destruction_req, &curr->elem);
+        }
 
-		/* Before switching the thread, we first save the information
-		 * of current running. */
-		thread_launch (next);
-	}
+        /* Before switching the thread, we first save the information
+         * of current running. */
+        thread_launch(next);
+    }
 }
 
 /* Returns a tid to use for a new thread. */
-static tid_t
-allocate_tid (void) {
-	static tid_t next_tid = 1;
-	tid_t tid;
+static tid_t allocate_tid(void)
+{
+    static tid_t next_tid = 1;
+    tid_t tid;
 
-	lock_acquire (&tid_lock);
-	tid = next_tid++;
-	lock_release (&tid_lock);
+    lock_acquire(&tid_lock);
+    tid = next_tid++;
+    lock_release(&tid_lock);
 
-	return tid;
+    return tid;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 연결해주세요 -->
closes #7 

## 📌 작업 내용
### 구현 사항
<!-- 구현내용에 대해서 설명해주세요. -->
- `timer_sleep()`에서 busy waiting을 제거하고, sleep_list 기반 blocked wait 방식으로 재구현
- `sleep_list` 자료구조 및 `wakeup_tick_less()` 비교 함수를 도입하여 스레드를 깨울 시점을 tick 기준으로 관리
- `timer_interrupt()`에서 현재 tick 이상이 된 스레드를 찾아 unblock하는 sleep/wakeup 메커니즘 구현

### 변경된 파일
<!-- 구현 내용으로 인해 변경된 파일에 대해 설명해주세요 -->
- `devices/timer.c`
  - `timer_sleep()` busy waiting → sleep/wakeup 메커니즘 전환
  - `sleep_list` 전역 변수 선언 및 `timer_init()`에서 초기화
  - `wakeup_tick_less()` 비교 함수 구현
  - `timer_interrupt()`에서 깨울 스레드 탐색 및 unblock 처리
  - 기존 코드에 팀 포매팅 규칙 적용
- `thread.c` 
  - 코드 스타일 포매팅만 적용 (로직 변경 없음)
- `include/threads/thread.h`
  - `struct thread`에 `int64_t wakeup_tick` 필드 추가: 스레드가 깨어날 tick 저장
  - `struct thread`에 `struct list_elem sleep_elem` 필드 추가: sleep_list 연결용

### 추가 사항
<!-- 트러블 슈팅 등 추가로 설명할 내용이 있으시다면 아래에 작성해주세요. -->
- busy waiting 제거 후 alarm-* 관련 테스트를 실행하여 정상 동작 여부를 확인했습니다.

## ✅ 셀프 체크리스트
<!-- 체크리스트를 모두 완료한 후 제출해주세요 -->
<!-- 완료 처리를 표시하려면 [x], 완료되지 않았다면 [ ] -->
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 관련 테스트가 모두 통과하나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?
