### PR TITLE
feat: 우선순위 기반 스케줄링 구현

### DIFF
--- a/devices/timer.c
+++ b/devices/timer.c
@@ -209,9 +209,16 @@ static void real_time_sleep(int64_t num, int32_t denom)
     }
 }
 
+/* 알람 대기 리스트에서 두 스레드의 순서를 비교
+   1순위: 깨어날 시간(wakeup_tick)이 빠른 스레드가 먼저
+   2순위: wakeup_tick이 같으면 priority(우선순위)가 높은 스레드가 먼저 */
 static bool wakeup_tick_less(const struct list_elem* a, const struct list_elem* b, void* aux UNUSED)
 {
     struct thread* ta = list_entry(a, struct thread, sleep_elem);
     struct thread* tb = list_entry(b, struct thread, sleep_elem);
-    return ta->wakeup_tick < tb->wakeup_tick;
+
+    if (ta->wakeup_tick != tb->wakeup_tick)
+        return ta->wakeup_tick < tb->wakeup_tick;
+
+    return ta->priority > tb->priority;
 }

--- a/devices/timer.c
+++ b/devices/timer.c
@@ -209,16 +209,11 @@ static void real_time_sleep(int64_t num, int32_t denom)
     }
 }
 
-/* 알람 대기 리스트에서 두 스레드의 순서를 비교
-   1순위: 깨어날 시간(wakeup_tick)이 빠른 스레드가 먼저
-   2순위: wakeup_tick이 같으면 priority(우선순위)가 높은 스레드가 먼저 */
+/* 알람 대기 리스트에서 두 스레드의 순서를 비교 */
 static bool wakeup_tick_less(const struct list_elem* a, const struct list_elem* b, void* aux UNUSED)
 {
     struct thread* ta = list_entry(a, struct thread, sleep_elem);
     struct thread* tb = list_entry(b, struct thread, sleep_elem);
 
-    if (ta->wakeup_tick != tb->wakeup_tick)
-        return ta->wakeup_tick < tb->wakeup_tick;
-
-    return ta->priority > tb->priority;
+    return ta->wakeup_tick < tb->wakeup_tick;
 }

--- a/include/threads/synch.h
+++ b/include/threads/synch.h
@@ -6,43 +6,43 @@
 
 /* A counting semaphore. */
 struct semaphore {
-	unsigned value;             /* Current value. */
-	struct list waiters;        /* List of waiting threads. */
+    unsigned value;      /* Current value. */
+    struct list waiters; /* List of waiting threads. */
 };
 
-void sema_init (struct semaphore *, unsigned value);
-void sema_down (struct semaphore *);
-bool sema_try_down (struct semaphore *);
-void sema_up (struct semaphore *);
-void sema_self_test (void);
+void sema_init(struct semaphore*, unsigned value);
+void sema_down(struct semaphore*);
+bool sema_try_down(struct semaphore*);
+void sema_up(struct semaphore*);
+void sema_self_test(void);
 
 /* Lock. */
 struct lock {
-	struct thread *holder;      /* Thread holding lock (for debugging). */
-	struct semaphore semaphore; /* Binary semaphore controlling access. */
+    struct thread* holder;      /* Thread holding lock (for debugging). */
+    struct semaphore semaphore; /* Binary semaphore controlling access. */
 };
 
-void lock_init (struct lock *);
-void lock_acquire (struct lock *);
-bool lock_try_acquire (struct lock *);
-void lock_release (struct lock *);
-bool lock_held_by_current_thread (const struct lock *);
+void lock_init(struct lock*);
+void lock_acquire(struct lock*);
+bool lock_try_acquire(struct lock*);
+void lock_release(struct lock*);
+bool lock_held_by_current_thread(const struct lock*);
 
 /* Condition variable. */
 struct condition {
-	struct list waiters;        /* List of waiting threads. */
+    struct list waiters; /* List of waiting threads. */
 };
 
-void cond_init (struct condition *);
-void cond_wait (struct condition *, struct lock *);
-void cond_signal (struct condition *, struct lock *);
-void cond_broadcast (struct condition *, struct lock *);
+void cond_init(struct condition*);
+void cond_wait(struct condition*, struct lock*);
+void cond_signal(struct condition*, struct lock*);
+void cond_broadcast(struct condition*, struct lock*);
 
 /* Optimization barrier.
  *
  * The compiler will not reorder operations across an
  * optimization barrier.  See "Optimization Barriers" in the
  * reference guide for more information.*/
-#define barrier() asm volatile ("" : : : "memory")
+#define barrier() asm volatile("" : : : "memory")
 
 #endif /* threads/synch.h */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -145,4 +145,6 @@ int thread_get_load_avg(void);
 
 void do_iret(struct intr_frame* tf);
 
+bool cmp_priority(const struct list_elem* a, const struct list_elem* b, void* aux UNUSED);
+
 #endif /* threads/thread.h */

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -41,12 +41,12 @@
 
    - up or "V": increment the value (and wake up one waiting
    thread, if any). */
-void
-sema_init (struct semaphore *sema, unsigned value) {
-	ASSERT (sema != NULL);
+void sema_init(struct semaphore* sema, unsigned value)
+{
+    ASSERT(sema != NULL);
 
-	sema->value = value;
-	list_init (&sema->waiters);
+    sema->value = value;
+    list_init(&sema->waiters);
 }
 
 /* Down or "P" operation on a semaphore.  Waits for SEMA's value
@@ -57,20 +57,20 @@ sema_init (struct semaphore *sema, unsigned value) {
    interrupts disabled, but if it sleeps then the next scheduled
    thread will probably turn interrupts back on. This is
    sema_down function. */
-void
-sema_down (struct semaphore *sema) {
-	enum intr_level old_level;
+void sema_down(struct semaphore* sema)
+{
+    enum intr_level old_level;
 
-	ASSERT (sema != NULL);
-	ASSERT (!intr_context ());
+    ASSERT(sema != NULL);
+    ASSERT(!intr_context());
 
-	old_level = intr_disable ();
-	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
-		thread_block ();
-	}
-	sema->value--;
-	intr_set_level (old_level);
+    old_level = intr_disable();
+    while (sema->value == 0) {
+        list_push_back(&sema->waiters, &thread_current()->elem);
+        thread_block();
+    }
+    sema->value--;
+    intr_set_level(old_level);
 }
 
 /* Down or "P" operation on a semaphore, but only if the
@@ -78,79 +78,74 @@ sema_down (struct semaphore *sema) {
    decremented, false otherwise.
 
    This function may be called from an interrupt handler. */
-bool
-sema_try_down (struct semaphore *sema) {
-	enum intr_level old_level;
-	bool success;
+bool sema_try_down(struct semaphore* sema)
+{
+    enum intr_level old_level;
+    bool success;
 
-	ASSERT (sema != NULL);
+    ASSERT(sema != NULL);
 
-	old_level = intr_disable ();
-	if (sema->value > 0)
-	{
-		sema->value--;
-		success = true;
-	}
-	else
-		success = false;
-	intr_set_level (old_level);
+    old_level = intr_disable();
+    if (sema->value > 0) {
+        sema->value--;
+        success = true;
+    } else
+        success = false;
+    intr_set_level(old_level);
 
-	return success;
+    return success;
 }
 
 /* Up or "V" operation on a semaphore.  Increments SEMA's value
    and wakes up one thread of those waiting for SEMA, if any.
 
    This function may be called from an interrupt handler. */
-void
-sema_up (struct semaphore *sema) {
-	enum intr_level old_level;
+void sema_up(struct semaphore* sema)
+{
+    enum intr_level old_level;
 
-	ASSERT (sema != NULL);
+    ASSERT(sema != NULL);
 
-	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
-	sema->value++;
-	intr_set_level (old_level);
+    old_level = intr_disable();
+    if (!list_empty(&sema->waiters))
+        thread_unblock(list_entry(list_pop_front(&sema->waiters), struct thread, elem));
+    sema->value++;
+    intr_set_level(old_level);
 }
 
-static void sema_test_helper (void *sema_);
+static void sema_test_helper(void* sema_);
 
 /* Self-test for semaphores that makes control "ping-pong"
    between a pair of threads.  Insert calls to printf() to see
    what's going on. */
-void
-sema_self_test (void) {
-	struct semaphore sema[2];
-	int i;
+void sema_self_test(void)
+{
+    struct semaphore sema[2];
+    int i;
 
-	printf ("Testing semaphores...");
-	sema_init (&sema[0], 0);
-	sema_init (&sema[1], 0);
-	thread_create ("sema-test", PRI_DEFAULT, sema_test_helper, &sema);
-	for (i = 0; i < 10; i++)
-	{
-		sema_up (&sema[0]);
-		sema_down (&sema[1]);
-	}
-	printf ("done.\n");
+    printf("Testing semaphores...");
+    sema_init(&sema[0], 0);
+    sema_init(&sema[1], 0);
+    thread_create("sema-test", PRI_DEFAULT, sema_test_helper, &sema);
+    for (i = 0; i < 10; i++) {
+        sema_up(&sema[0]);
+        sema_down(&sema[1]);
+    }
+    printf("done.\n");
 }
 
 /* Thread function used by sema_self_test(). */
-static void
-sema_test_helper (void *sema_) {
-	struct semaphore *sema = sema_;
-	int i;
+static void sema_test_helper(void* sema_)
+{
+    struct semaphore* sema = sema_;
+    int i;
 
-	for (i = 0; i < 10; i++)
-	{
-		sema_down (&sema[0]);
-		sema_up (&sema[1]);
-	}
+    for (i = 0; i < 10; i++) {
+        sema_down(&sema[0]);
+        sema_up(&sema[1]);
+    }
 }
-
+
 /* Initializes LOCK.  A lock can be held by at most a single
    thread at any given time.  Our locks are not "recursive", that
    is, it is an error for the thread currently holding a lock to
@@ -166,12 +161,12 @@ sema_test_helper (void *sema_) {
    acquire and release it.  When these restrictions prove
    onerous, it's a good sign that a semaphore should be used,
    instead of a lock. */
-void
-lock_init (struct lock *lock) {
-	ASSERT (lock != NULL);
+void lock_init(struct lock* lock)
+{
+    ASSERT(lock != NULL);
 
-	lock->holder = NULL;
-	sema_init (&lock->semaphore, 1);
+    lock->holder = NULL;
+    sema_init(&lock->semaphore, 1);
 }
 
 /* Acquires LOCK, sleeping until it becomes available if
@@ -182,14 +177,14 @@ lock_init (struct lock *lock) {
    interrupt handler.  This function may be called with
    interrupts disabled, but interrupts will be turned back on if
    we need to sleep. */
-void
-lock_acquire (struct lock *lock) {
-	ASSERT (lock != NULL);
-	ASSERT (!intr_context ());
-	ASSERT (!lock_held_by_current_thread (lock));
+void lock_acquire(struct lock* lock)
+{
+    ASSERT(lock != NULL);
+    ASSERT(!intr_context());
+    ASSERT(!lock_held_by_current_thread(lock));
 
-	sema_down (&lock->semaphore);
-	lock->holder = thread_current ();
+    sema_down(&lock->semaphore);
+    lock->holder = thread_current();
 }
 
 /* Tries to acquires LOCK and returns true if successful or false
@@ -198,17 +193,17 @@ lock_acquire (struct lock *lock) {
 
    This function will not sleep, so it may be called within an
    interrupt handler. */
-bool
-lock_try_acquire (struct lock *lock) {
-	bool success;
+bool lock_try_acquire(struct lock* lock)
+{
+    bool success;
 
-	ASSERT (lock != NULL);
-	ASSERT (!lock_held_by_current_thread (lock));
+    ASSERT(lock != NULL);
+    ASSERT(!lock_held_by_current_thread(lock));
 
-	success = sema_try_down (&lock->semaphore);
-	if (success)
-		lock->holder = thread_current ();
-	return success;
+    success = sema_try_down(&lock->semaphore);
+    if (success)
+        lock->holder = thread_current();
+    return success;
 }
 
 /* Releases LOCK, which must be owned by the current thread.
@@ -217,39 +212,39 @@ lock_try_acquire (struct lock *lock) {
    An interrupt handler cannot acquire a lock, so it does not
    make sense to try to release a lock within an interrupt
    handler. */
-void
-lock_release (struct lock *lock) {
-	ASSERT (lock != NULL);
-	ASSERT (lock_held_by_current_thread (lock));
+void lock_release(struct lock* lock)
+{
+    ASSERT(lock != NULL);
+    ASSERT(lock_held_by_current_thread(lock));
 
-	lock->holder = NULL;
-	sema_up (&lock->semaphore);
+    lock->holder = NULL;
+    sema_up(&lock->semaphore);
 }
 
 /* Returns true if the current thread holds LOCK, false
    otherwise.  (Note that testing whether some other thread holds
    a lock would be racy.) */
-bool
-lock_held_by_current_thread (const struct lock *lock) {
-	ASSERT (lock != NULL);
+bool lock_held_by_current_thread(const struct lock* lock)
+{
+    ASSERT(lock != NULL);
 
-	return lock->holder == thread_current ();
+    return lock->holder == thread_current();
 }
-
+
 /* One semaphore in a list. */
 struct semaphore_elem {
-	struct list_elem elem;              /* List element. */
-	struct semaphore semaphore;         /* This semaphore. */
+    struct list_elem elem;      /* List element. */
+    struct semaphore semaphore; /* This semaphore. */
 };
 
 /* Initializes condition variable COND.  A condition variable
    allows one piece of code to signal a condition and cooperating
    code to receive the signal and act upon it. */
-void
-cond_init (struct condition *cond) {
-	ASSERT (cond != NULL);
+void cond_init(struct condition* cond)
+{
+    ASSERT(cond != NULL);
 
-	list_init (&cond->waiters);
+    list_init(&cond->waiters);
 }
 
 /* Atomically releases LOCK and waits for COND to be signaled by
@@ -272,20 +267,20 @@ cond_init (struct condition *cond) {
    interrupt handler.  This function may be called with
    interrupts disabled, but interrupts will be turned back on if
    we need to sleep. */
-void
-cond_wait (struct condition *cond, struct lock *lock) {
-	struct semaphore_elem waiter;
+void cond_wait(struct condition* cond, struct lock* lock)
+{
+    struct semaphore_elem waiter;
 
-	ASSERT (cond != NULL);
-	ASSERT (lock != NULL);
-	ASSERT (!intr_context ());
-	ASSERT (lock_held_by_current_thread (lock));
+    ASSERT(cond != NULL);
+    ASSERT(lock != NULL);
+    ASSERT(!intr_context());
+    ASSERT(lock_held_by_current_thread(lock));
 
-	sema_init (&waiter.semaphore, 0);
-	list_push_back (&cond->waiters, &waiter.elem);
-	lock_release (lock);
-	sema_down (&waiter.semaphore);
-	lock_acquire (lock);
+    sema_init(&waiter.semaphore, 0);
+    list_push_back(&cond->waiters, &waiter.elem);
+    lock_release(lock);
+    sema_down(&waiter.semaphore);
+    lock_acquire(lock);
 }
 
 /* If any threads are waiting on COND (protected by LOCK), then
@@ -295,16 +290,15 @@ cond_wait (struct condition *cond, struct lock *lock) {
    An interrupt handler cannot acquire a lock, so it does not
    make sense to try to signal a condition variable within an
    interrupt handler. */
-void
-cond_signal (struct condition *cond, struct lock *lock UNUSED) {
-	ASSERT (cond != NULL);
-	ASSERT (lock != NULL);
-	ASSERT (!intr_context ());
-	ASSERT (lock_held_by_current_thread (lock));
+void cond_signal(struct condition* cond, struct lock* lock UNUSED)
+{
+    ASSERT(cond != NULL);
+    ASSERT(lock != NULL);
+    ASSERT(!intr_context());
+    ASSERT(lock_held_by_current_thread(lock));
 
-	if (!list_empty (&cond->waiters))
-		sema_up (&list_entry (list_pop_front (&cond->waiters),
-					struct semaphore_elem, elem)->semaphore);
+    if (!list_empty(&cond->waiters))
+        sema_up(&list_entry(list_pop_front(&cond->waiters), struct semaphore_elem, elem)->semaphore);
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by
@@ -313,11 +307,11 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
    An interrupt handler cannot acquire a lock, so it does not
    make sense to try to signal a condition variable within an
    interrupt handler. */
-void
-cond_broadcast (struct condition *cond, struct lock *lock) {
-	ASSERT (cond != NULL);
-	ASSERT (lock != NULL);
+void cond_broadcast(struct condition* cond, struct lock* lock)
+{
+    ASSERT(cond != NULL);
+    ASSERT(lock != NULL);
 
-	while (!list_empty (&cond->waiters))
-		cond_signal (cond, lock);
+    while (!list_empty(&cond->waiters))
+        cond_signal(cond, lock);
 }

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -32,6 +32,8 @@
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 
+static bool cmp_cond_waiter_priority(const struct list_elem* a, const struct list_elem* b, void* aux UNUSED);
+
 /* Initializes semaphore SEMA to VALUE.  A semaphore is a
    nonnegative integer along with two atomic operators for
    manipulating it:
@@ -306,8 +308,10 @@ void cond_signal(struct condition* cond, struct lock* lock UNUSED)
     ASSERT(!intr_context());
     ASSERT(lock_held_by_current_thread(lock));
 
-    if (!list_empty(&cond->waiters))
+    if (!list_empty(&cond->waiters)) {
+        list_sort(&cond->waiters, cmp_cond_waiter_priority, NULL);
         sema_up(&list_entry(list_pop_front(&cond->waiters), struct semaphore_elem, elem)->semaphore);
+    }
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by
@@ -323,4 +327,22 @@ void cond_broadcast(struct condition* cond, struct lock* lock)
 
     while (!list_empty(&cond->waiters))
         cond_signal(cond, lock);
+}
+
+/* 조건 변수(Conditional variable) 대기자의 우선순위(priority) 비교 함수 */
+static bool cmp_cond_waiter_priority(const struct list_elem* a, const struct list_elem* b, void* aux UNUSED)
+{
+    struct semaphore_elem* sa = list_entry(a, struct semaphore_elem, elem);
+    struct semaphore_elem* sb = list_entry(b, struct semaphore_elem, elem);
+
+    // 각 세마포어의 waiters에서 맨 앞(최고 우선순위) 스레드 비교
+    // sema_down/up에서 각 세마포어의 waiters는 항상 정렬된 상태 유지
+    struct list_elem* ea = list_begin(&sa->semaphore.waiters);
+    struct list_elem* eb = list_begin(&sb->semaphore.waiters);
+
+    struct thread* ta = list_entry(ea, struct thread, elem);
+    struct thread* tb = list_entry(eb, struct thread, elem);
+
+    // true면 a가 b보다 앞에 위치 (우선순위 내림차순 정렬)
+    return ta->priority > tb->priority;
 }

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -68,7 +68,7 @@ void sema_down(struct semaphore* sema)
 
     old_level = intr_disable();
     while (sema->value == 0) {
-        list_insert_ordered(&sema->waiters, &thread_current()->elem, cmp_priority, NULL);
+        list_push_back(&sema->waiters, &thread_current()->elem);
         thread_block();
     }
     sema->value--;
@@ -111,8 +111,10 @@ void sema_up(struct semaphore* sema)
 
     old_level = intr_disable();
     if (!list_empty(&sema->waiters)) {
-        struct list_elem* e = list_pop_front(&sema->waiters);
-        unblocked = list_entry(e, struct thread, elem);
+        /* cmp_priority는 내림차순(>)이므로 list_min이 최고 우선순위 반환 */
+        struct list_elem* max_elem = list_min(&sema->waiters, cmp_priority, NULL);
+        list_remove(max_elem);
+        unblocked = list_entry(max_elem, struct thread, elem);
         thread_unblock(unblocked);
     }
     sema->value++;

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -66,7 +66,7 @@ void sema_down(struct semaphore* sema)
 
     old_level = intr_disable();
     while (sema->value == 0) {
-        list_push_back(&sema->waiters, &thread_current()->elem);
+        list_insert_ordered(&sema->waiters, &thread_current()->elem, cmp_priority, NULL);
         thread_block();
     }
     sema->value--;
@@ -103,14 +103,23 @@ bool sema_try_down(struct semaphore* sema)
 void sema_up(struct semaphore* sema)
 {
     enum intr_level old_level;
+    struct thread* unblocked = NULL; /* sema_up을 대기하고 있던 Thread */
 
     ASSERT(sema != NULL);
 
     old_level = intr_disable();
-    if (!list_empty(&sema->waiters))
-        thread_unblock(list_entry(list_pop_front(&sema->waiters), struct thread, elem));
+    if (!list_empty(&sema->waiters)) {
+        struct list_elem* e = list_pop_front(&sema->waiters);
+        unblocked = list_entry(e, struct thread, elem);
+        thread_unblock(unblocked);
+    }
     sema->value++;
     intr_set_level(old_level);
+
+    /* 인터럽트 컨텍스트가 아니고, 깨어난 스레드의 우선순위가 더 높으면 양보 */
+    if (!intr_context() && unblocked && unblocked->priority > thread_current()->priority) {
+        thread_yield();
+    }
 }
 
 static void sema_test_helper(void* sema_);

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -311,8 +311,10 @@ void cond_signal(struct condition* cond, struct lock* lock UNUSED)
     ASSERT(lock_held_by_current_thread(lock));
 
     if (!list_empty(&cond->waiters)) {
-        list_sort(&cond->waiters, cmp_cond_waiter_priority, NULL);
-        sema_up(&list_entry(list_pop_front(&cond->waiters), struct semaphore_elem, elem)->semaphore);
+        /* cmp_cond_waiter_priority는 내림차순(>)이므로 list_min이 최고 우선순위 반환 */
+        struct list_elem* max_elem = list_min(&cond->waiters, cmp_cond_waiter_priority, NULL);
+        list_remove(max_elem);
+        sema_up(&list_entry(max_elem, struct semaphore_elem, elem)->semaphore);
     }
 }
 

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -62,7 +62,6 @@ static void init_thread(struct thread*, const char* name, int priority);
 static void do_schedule(int status);
 static void schedule(void);
 static tid_t allocate_tid(void);
-static bool cmp_priority(const struct list_elem* a, const struct list_elem* b, void* aux UNUSED);
 
 /* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
@@ -593,7 +592,7 @@ static tid_t allocate_tid(void)
     return tid;
 }
 
-static bool cmp_priority(const struct list_elem* a, const struct list_elem* b, void* aux UNUSED)
+bool cmp_priority(const struct list_elem* a, const struct list_elem* b, void* aux UNUSED)
 {
     struct thread* ta = list_entry(a, struct thread, elem);
     struct thread* tb = list_entry(b, struct thread, elem);

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -62,6 +62,7 @@ static void init_thread(struct thread*, const char* name, int priority);
 static void do_schedule(int status);
 static void schedule(void);
 static tid_t allocate_tid(void);
+static bool cmp_priority(const struct list_elem* a, const struct list_elem* b, void* aux UNUSED);
 
 /* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
@@ -201,6 +202,10 @@ tid_t thread_create(const char* name, int priority, thread_func* function, void*
     /* Add to run queue. */
     thread_unblock(t);
 
+    if (t->priority > thread_current()->priority) {
+        thread_yield();
+    }
+
     return tid;
 }
 
@@ -234,7 +239,7 @@ void thread_unblock(struct thread* t)
 
     old_level = intr_disable();
     ASSERT(t->status == THREAD_BLOCKED);
-    list_push_back(&ready_list, &t->elem);
+    list_insert_ordered(&ready_list, &t->elem, cmp_priority, NULL);
     t->status = THREAD_READY;
     intr_set_level(old_level);
 }
@@ -297,7 +302,7 @@ void thread_yield(void)
 
     old_level = intr_disable();
     if (curr != idle_thread)
-        list_push_back(&ready_list, &curr->elem);
+        list_insert_ordered(&ready_list, &curr->elem, cmp_priority, NULL);
     do_schedule(THREAD_READY);
     intr_set_level(old_level);
 }
@@ -306,6 +311,11 @@ void thread_yield(void)
 void thread_set_priority(int new_priority)
 {
     thread_current()->priority = new_priority;
+    if (!list_empty(&ready_list)) {
+        struct thread* begin = list_entry(list_begin(&ready_list), struct thread, elem);
+        if (begin->priority > new_priority)
+            thread_yield();
+    }
 }
 
 /* Returns the current thread's priority. */
@@ -581,4 +591,11 @@ static tid_t allocate_tid(void)
     lock_release(&tid_lock);
 
     return tid;
+}
+
+static bool cmp_priority(const struct list_elem* a, const struct list_elem* b, void* aux UNUSED)
+{
+    struct thread* ta = list_entry(a, struct thread, elem);
+    struct thread* tb = list_entry(b, struct thread, elem);
+    return ta->priority > tb->priority;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 연결해주세요 -->
closes #10 

## 📌 작업 내용
### 구현 사항
<!-- 구현내용에 대해서 설명해주세요. -->
<!-- 예시 :
- 이슈 템플릿, PR 템플릿 작성
- READEME 파일 최초 작성
 --> 
- 우선순위 기반 스케줄링 구현: `ready_list`를 우선순위 순 정렬
- 세마포어 우선순위 스케줄링 지원: 최고 우선순위 스레드 먼저 깨움
- 조건 변수 우선순위 스케줄링 지원: `signal` 시 최고 우선순위 스레드 선택
- `sleep_list` 정렬 시 동일 `wake_tick`에 대해 `priority` 고려

### 변경된 파일
<!-- 구현 내용으로 인해 변경된 파일에 대해 설명해주세요 -->
<!-- 예시:
- README.md
  - readme 파일 최초 생성
- issue_template.md
  - 이슈 템플릿 최초 생성
-->
- `thread.c`, `thread.h`
  - `cmp_priority()` 전역 함수로 변경
  - `thread_create()`: 새 스레드 우선순위가 높으면 즉시 yield
  - `thread_unblock()`, `thread_yield()`: ready_list 우선순위 순 정렬
- `synch.c`
  - `sema_down()`: waiters에 `list_push_back`으로 삽입
  - `sema_up()`: `list_min`으로 최고 우선순위 스레드 탐색 및 선점
  - `cond_signal()`: waiters 재정렬 후 최고 우선순위 스레드 깨움
  - `cmp_cond_waiter_priority()` 비교 함수 추가
- `timer.c`
  - sleep_list 정렬 기준에 priority 추가

### 추가 사항
<!-- 트러블 슈팅 등 추가로 설명할 내용이 있으시다면 아래에 작성해주세요. -->
- `sema_up()`에서 `list_min()` 사용 이유: `cmp_priority`가 내림차순(>) 비교이므로 `list_min`이 최고 우선순위 반환
- priority donation 대비 삽입 시 정렬 대신 탐색 시 최고 우선순위 선택 방식 채택

## ✅ 셀프 체크리스트
<!-- 체크리스트를 모두 완료한 후 제출해주세요 -->
<!-- 완료 처리를 표시하려면 [x], 완료되지 않았다면 [ ] -->
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 관련 테스트가 모두 통과하나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?
